### PR TITLE
Update _color-functions.scss

### DIFF
--- a/src/sass/_color-functions.scss
+++ b/src/sass/_color-functions.scss
@@ -1,8 +1,9 @@
 @import '~mathsass/dist/math';
+@use "sass:math";
 
 // ported from chroma.js
-$degrees-2-radians: $PI / 180;
-$radians-2-degrees: 180 / $PI;
+$degrees-2-radians: math.div($PI, 180);
+$radians-2-degrees: math.div(180, $PI);
 
 // D65 standard referent
 $lab-Xn: 0.950470;


### PR DESCRIPTION
This change means there is no longer a deprecation warning on compile. This is the warning:

"DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0."